### PR TITLE
[finish] admin-devise

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,10 @@
 class ApplicationController < ActionController::Base
+  def after_sign_in_path_for(resource)
+  case resource
+  when Admin
+    admin_orders_path
+  when Customer
+    root_path
+  end
+end
 end

--- a/app/models/admin.rb
+++ b/app/models/admin.rb
@@ -3,4 +3,5 @@ class Admin < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
+         
 end

--- a/app/views/admin/registrations/new.html.erb
+++ b/app/views/admin/registrations/new.html.erb
@@ -1,8 +1,6 @@
 <h2>Sign up</h2>
 
 <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
-  <%= render "admins/shared/error_messages", resource: resource %>
-
   <div class="field">
     <%= f.label :email %><br />
     <%= f.email_field :email, autofocus: true, autocomplete: "email" %>

--- a/app/views/admin/sessions/new.html.erb
+++ b/app/views/admin/sessions/new.html.erb
@@ -1,6 +1,8 @@
 <h2>Log in</h2>
 
 <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
+  <%= render "admin/shared/error_messages", resource: resource %>
+
   <div class="field">
     <%= f.label :email %><br />
     <%= f.email_field :email, autofocus: true, autocomplete: "email" %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,6 +10,10 @@
   </head>
 
   <body>
+    <%# deivseのフラッシュメッセージを表示 %>
+    <p class="notice"><%= notice %></p>
+    <p class="alert"><%= alert %></p>
+
     <%= yield %>
   </body>
 </html>

--- a/config/application.rb
+++ b/config/application.rb
@@ -11,9 +11,15 @@ module NaganoCake1
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.2
 
+    #日本語化適用のための記述
+    config.i18n.default_locale = :ja 
+
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading
     # the framework and any gems in your application.
   end
+
+
+
 end

--- a/config/locales/devise.views.ja.yml
+++ b/config/locales/devise.views.ja.yml
@@ -115,6 +115,7 @@ ja:
         sign_in: ログイン
       signed_in: ログインしました。
       signed_out: ログアウトしました。
+      invalid: "%{authentication_keys}またはパスワードが違います。"
     shared:
       links:
         back: 戻る

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,4 +12,33 @@ devise_for :admin, skip: [:registrations, :passwords] ,controllers: {
   sessions: "admin/sessions"
 }
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
+
+  #Customer側のルーティング
+  root 'homes#top'
+  get 'about' => 'homes#about'
+  resources :items, only: [:index, :show]
+  
+  resources :cart_items, only: [:index, :create, :update, :destroy]
+  get 'cart_items/all_destroy' => 'customer/cart_items'
+  
+  resource :customers, only: [:show, :edit, :update]
+  patch 'customers/withdraw' => 'customer/customers#withdraw'
+  get 'customers/unsubscribe' => 'customer/customers#unsubscribe'
+  
+  resources :orders, only: [:index, :show, :new, :create]
+  get 'orders/confirm' => 'customer/orders#confirm'
+  get 'orders/thanx' => 'customer/orders#thanx'
+
+  resources :addresses, except: [:new, :show]
+  
+
+  #admin側のルーティング
+  namespace :admin do
+    resources :items, except: [:destroy]
+    resources :genres, except: [:new, :show, :destroy]
+    resources :customers, except: [:new, :create, :destroy]
+    resources :orders, only: [:index, :show, :update, :index_customer]
+    put 'admin/orders_details/:id', to: 'order_details#update'
+  end
+ 
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,3 +5,8 @@
 #
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
+
+  Admin.create!(
+    email: 'test@test.com',
+    password: 'testtesttest'
+  )


### PR DESCRIPTION
## admin側devise作成
### 追加機能
- ログイン機能
- 会員情報登録（管理者側メール、パスワード）
- ログイン後遷移先変更（管理者及び顧客側）
- deviseエラーメッセージ日本語化
- ルーティング設定（顧客及び管理者）