### PR TITLE
Adminorders

### DIFF
--- a/app/controllers/admin/orders_controller.rb
+++ b/app/controllers/admin/orders_controller.rb
@@ -25,7 +25,7 @@ class Admin::OrdersController < ApplicationController
 
   def index_customer
     @customer_orders = Order.where(customer_id: params[:id]).page(params[:page]).per(10)
-    @customer_name = Order.find_by(customer_id: params[:id]).name
+    @customer_name = Order.find_by(customer_id: params[:id]).customer.full_name
   end
 
 

--- a/app/views/admin/customers/show.html.erb
+++ b/app/views/admin/customers/show.html.erb
@@ -52,7 +52,7 @@
                 <tr>
                   <td></td>
                   <td class="px-5"><%= link_to "編集する", edit_admin_customer_path, class: 'btn btn-success mr-5' %>
-                  <%= link_to "注文履歴一覧を見る", admin_customer_orders_path(@customer), class: 'btn  btn-primary ml-5' %></td>
+                  <%= link_to "注文履歴一覧を見る", admin_orders_path, class: 'btn  btn-primary ml-5' %></td>
                 </tr>
               </tbody>
            </table>

--- a/app/views/admin/orders/index.html.erb
+++ b/app/views/admin/orders/index.html.erb
@@ -14,7 +14,7 @@
         <% @orders.each do |order| %>
         <tr>
           <td><u><%= link_to order.created_at.strftime("%Y/%m/%d %H:%M:%S"), admin_order_path(order.id), class: "text-dark" %></u></td>
-          <td><u><%= link_to order.name, admin_customer_orders_path(order.customer_id), class: "text-dark" %></u></td>
+          <td><u><%= link_to order.customer.full, admin_customer_orders_path(order.customer_id), class: "text-dark" %></u></td>
           <td><%= order.order_items.sum(:quantity) %></td>
           <td><%= order.status_i18n %></td>
         </tr>

--- a/app/views/admin/orders/index.html.erb
+++ b/app/views/admin/orders/index.html.erb
@@ -14,7 +14,7 @@
         <% @orders.each do |order| %>
         <tr>
           <td><u><%= link_to order.created_at.strftime("%Y/%m/%d %H:%M:%S"), admin_order_path(order.id), class: "text-dark" %></u></td>
-          <td><u><%= link_to order.customer.full, admin_customer_orders_path(order.customer_id), class: "text-dark" %></u></td>
+          <td><u><%= link_to order.customer.full_name, admin_customer_orders_path(order.customer_id), class: "text-dark" %></u></td>
           <td><%= order.order_items.sum(:quantity) %></td>
           <td><%= order.status_i18n %></td>
         </tr>

--- a/app/views/admin/orders/index_customer.html.erb
+++ b/app/views/admin/orders/index_customer.html.erb
@@ -14,7 +14,7 @@
         <% @customer_orders.each do |customer_order| %>
         <tr>
           <td><u><%= link_to customer_order.created_at.strftime("%Y/%m/%d %H:%M:%S"), admin_order_path(customer_order.id), class: "text-dark" %></u></td>
-          <td><u><%= link_to customer_order.name, admin_customer_path(customer_order.id), class: "text-dark" %></u></td>
+          <td><u><%= link_to customer_order.customer.full_name, admin_customer_path(customer_order.customer.id), class: "text-dark" %></u></td>
           <td><%= customer_order.order_items.sum(:quantity) %></td>
           <td><%= customer_order.status_i18n %></td>
         </tr>


### PR DESCRIPTION
## 管理者側注文履歴一覧画面修正
### 修正
- 注文履歴一覧、特定顧客注文履歴詳細画面の購入者の修正
- 〜さんの注文履歴一覧の〜の部分が正しく表示されるように修正
- 会員詳細画面の注文履歴一覧ボタンの遷移先を特定顧客注文履歴一覧から全体の注文履歴一覧画面に変更
- 注文履歴一覧、特定顧客注文履歴詳細画面の購入者についているリンクの遷移先の修正